### PR TITLE
default deploy env to production

### DIFF
--- a/lib/cli/deploy.coffee
+++ b/lib/cli/deploy.coffee
@@ -15,7 +15,6 @@ module.exports = (cli, args) ->
 
   if !args.env and fs.existsSync(path.join(args.path, 'app.production.coffee'))
     args.env = 'production'
-  delete args.env
 
   project = new Roots args.path, env: args.env
 


### PR DESCRIPTION
pass through ```args.env``` so deploy defaults to ```production```. not sure why args.env was deleted here.